### PR TITLE
Only run go versions 1.24 and up on macos-latest.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,12 @@ jobs:
             runs-on: macos-latest
           - go: 1.15.x
             runs-on: macos-latest
+          - go: 1.18.x
+            runs-on: macos-latest
+          - go: 1.19.x
+            runs-on: macos-latest
+          - go: 1.22.x
+            runs-on: macos-latest
 
     name: Go ${{ matrix.go }} on ${{ matrix.runs-on }}
 


### PR DESCRIPTION
macos-latest needs LC_UUID tagged binaries. Go adds support for this in 1.24.